### PR TITLE
Improved FFTW config

### DIFF
--- a/fft_benchmark.cpp
+++ b/fft_benchmark.cpp
@@ -38,9 +38,9 @@ void test_fft(size_t size, double time = 1.5)
     printf(">  [%9ld, ", (long)size);
     real* in  = aligned_malloc<real>(size * 2);
     real* out = aligned_malloc<real>(size * 2);
+    fft_benchmark<false> fft(size, out, out);
     fill_random(in, size * 2);
     std::copy(in, in + size * 2, out);
-    fft_benchmark<false> fft(size, out, out);
 
     fft.execute();
     fill_random(in, size * 2);

--- a/fftw.hpp
+++ b/fftw.hpp
@@ -23,7 +23,7 @@ public:
                                ( fftwf_complex* )in,
                                ( fftwf_complex* )out,
                                invert ? FFTW_BACKWARD : FFTW_FORWARD,
-                               FFTW_ESTIMATE );
+                               FFTW_MEASURE );
     }
     static std::string name() { return fftwf_version; }
     static std::string shortname() { return "FFTW"; }


### PR DESCRIPTION
The benchmark currently uses `FFTW_ESTIMATE`, which uses pre-packaged heuristics to choose its plans.  This is fine for single FFTs, but for multiple uses, other modes are faster.

`FFTW_MEASURE` enables runtime profiling to find a fast plan, as recommended in this [tutorial page](http://www.fftw.org/fftw3_doc/Complex-One_002dDimensional-DFTs.html#Complex-One_002dDimensional-DFTs).  This has some set-up cost, but I think it makes sense for a benchmark.

Here are a couple of graphs, illustrating the performance difference between the modes:

![graph-fftw-performance-small](https://user-images.githubusercontent.com/1957191/52243899-18c0a680-28d3-11e9-843b-dfd33dad9b21.png)

![graph-fftw-performance-larg](https://user-images.githubusercontent.com/1957191/52243902-1cecc400-28d3-11e9-8466-1122557b65b6.png)

_(Graphs taken from my WIP, which is how I figured this out.)_

As the graphs show, `FFTW_PATIENT` gets even faster results, but plan-searching is very slow for large sizes (e.g. 2^18), which is why I've suggested `FFTW_MEASURE` in this PR.  The ideal solution probably uses `FFTW_EXHAUSTIVE` along with [`fftw_set_timelimit()`](http://www.fftw.org/fftw3_doc/Planner-Flags.html) to limit the search time to some fixed number of seconds.

The plan-profiling uses the input/output arrays, which is why I have moved the benchmark object construction to before the random-data generation.