### PR TITLE
Docker environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Use the rootproject/root image as the base image
+FROM debian:stable-slim
+
+# Update package lists and install necessary packages
+ENV LANG=C.UTF-8
+ENV DEBIAN_FRONTEND noninteractive
+ENV NPROC=8
+
+COPY Dockerfile.packages packages
+RUN apt-get update -qq && \
+    ln -sf /usr/share/zoneinfo/UTC /etc/localtime && \
+    apt-get -y install $(cat packages | grep -v '#') && \
+    apt-get autoremove -y && \
+    apt-get clean -y && \
+    rm -rf /var/cache/apt/archives/* && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV LD_LIBRARY_PATH /usr/local/lib:/usr:/usr/lib/aarch64-linux-gnu
+
+WORKDIR /opt
+
+RUN wget https://github.com/kfrlib/kfr/archive/refs/tags/6.0.2.tar.gz
+RUN tar -xzvf 6.0.2.tar.gz
+RUN cd kfr-6.0.2 && mkdir build
+RUN cd kfr-6.0.2/build && cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+RUN cd kfr-6.0.2/build && make -j8 && make install
+
+RUN git clone https://github.com/kfrlib/fft-benchmark
+RUN cd fft-benchmark && mkdir -p build
+RUN cd fft-benchmark/build && cmake ..  -DCMAKE_PREFIX_PATH="/usr/local/lib/cmake"
+RUN cd fft-benchmark/build && make -j8
+
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update -qq && \
     rm -rf /var/cache/apt/archives/* && \
     rm -rf /var/lib/apt/lists/*
 
-ENV LD_LIBRARY_PATH /usr/local/lib:/usr:/usr/lib/aarch64-linux-gnu
+ENV LD_LIBRARY_PATH /usr/local/lib:/usr:/usr/lib/aarch64-linux-gnu:/usr/lib/x86_64-linux-gnu
 
 WORKDIR /opt
 

--- a/Dockerfile.packages
+++ b/Dockerfile.packages
@@ -1,0 +1,13 @@
+bash
+git
+wget
+make
+supervisor
+lsb-release
+gnupg2
+ca-certificates
+nano
+procps
+cmake
+clang
+libfftw3-dev


### PR DESCRIPTION
Hello @dancazarin 

I have been trying to setup fft-benchmark on my Macbook, but FFTW3 and KFR detection is not working smoothly.
So I have a docker environment that is setting the procedure for me. I think it is fine and safe for x86_64 and arm64 architectures. 

At this time, I confirm that FFTW3 and KFR are still not detected.
- About KFR, I put /usr/local/lib/cmake where KFR's cmake configuration stands and FFTW3 is not 
- About FFTW3, there is no such `find_package(FFTW3)`. I dont know where it is taken from, but it would be good to provide within this repository (in a ./cmake/ directory maybe?).